### PR TITLE
简入繁出词库应基于wubi86_jidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ __用极点输入法的原因__
 .
 ├── README.md                       # 当前说明文档
 ├── rime.lua                        # 可以输出系统变量的函数
-├── default.custom.yaml             # 用记自定义的一些输入方式或方向
+├── default.custom.yaml             # 用户自定义的一些输入方式或方向
 ├── pinyin_simp.dict.yaml           # 简体拼音码表 - 五笔中拼音输入需要的
 ├── pinyin_simp.schema.yaml         # 简体拼音解释器
 ├── squirrel.custom.yaml            # 鼠须管（for macOS）输入法候选词界面

--- a/default.custom.yaml
+++ b/default.custom.yaml
@@ -9,7 +9,8 @@
 patch:
   schema_list:
     - schema: wubi86_jidian
-    - schema: luna_pinyin_simp
+    - schema: wubi_pinyin
+    - schema: wubi_trad
 
   # Menu
   menu:

--- a/wubi_trad.schema.yaml
+++ b/wubi_trad.schema.yaml
@@ -57,7 +57,7 @@ speller:
   #max_code_length: 4
 
 translator:
-  dictionary: wubi86
+  dictionary: wubi86_jidian
   prism: wubi_trad
   enable_charset_filter: true
   disable_user_dict_for_patterns:
@@ -69,7 +69,7 @@ abc_segmentor:
 
 reverse_lookup:
   dictionary: pinyin_simp
-  prefix: "`"
+  prefix: "z"
   suffix: "'"
   tips: 〔拼音〕
   preedit_format:


### PR DESCRIPTION
目前简入繁出和五笔拼音方案都没有启用。
而且简入繁出的依赖词库错误，会导致即使安装了opencc也无法使用。
个人建议默认不启用luna_pinyin_simp，用户如有需要，可以自行添加。
把五笔相关的输入方案都启用的意义可能要更大些。