### PR TITLE
删除兼容区块的字符‘凉|秊|裏|隣|兀|嗀|郎’

### DIFF
--- a/wubi86_jidian.dict.yaml
+++ b/wubi86_jidian.dict.yaml
@@ -5518,7 +5518,6 @@ Apple	appl
 耿直	bofh
 职业性	bont
 隣	boqh
-隣	boqh
 出类拔萃	bora
 职业病	boug
 耿介	bowj
@@ -17400,7 +17399,6 @@ SD卡	sdhh
 縠	fpgc
 豰	fpgc
 轂	fpgc
-嗀	fpgc
 塜	fpge
 霥	fpge
 过于	fpgf
@@ -22635,7 +22633,6 @@ GoPro	gpr
 兀立	gquu
 裂痕	gquv
 兀	gqv
-兀	gqv
 一刹那	gqvf
 琤	gqvh
 肂	gqvh
@@ -68249,7 +68246,6 @@ T恤	tntl
 筕	ttfh
 TF卡	ttfhh
 秊	ttfj
-秊	ttfj
 筶	ttfk
 穳	ttfm
 籫	ttfm
@@ -73643,7 +73639,6 @@ m³	uuyy		立方
 门洞	uyim
 门派	uyir
 凉	uyiy
-凉	uyiy
 癠	uyjd
 辩明	uyje
 门里	uyjf
@@ -85238,7 +85233,6 @@ m³	uuyy		立方
 亯	yjf
 鄽	yjfb
 裏	yjfe
-裏	yjfe
 廛	yjff
 斉	yjff
 斎	yjfi
@@ -87666,7 +87660,6 @@ Windows	wind
 良	yve
 郞	yveb
 鄘	yveb
-郎	yveb
 良朋	yvee
 庸	yveh
 良	yvei


### PR DESCRIPTION
根据标准，兼容区块的字符是不应该使用的，应该使用统一区块内其所对应的字符
五笔码表中发现一些兼容字符
```
凉|秊|裏|隣|兀|嗀|郎
```
这几个字所对应的统一区块的字符为
```
凉|秊|裏|隣|兀|嗀|郎|郞
```
应该将那7个兼容字符删除

删除的理由还有：

1. 那7个兼容字符对应的统一区字符已在码表中有了
1. 这几兼容字符的，都仅是单字，未成词语。而对应的统一区字符成词语
1. 简单比较了一下7个兼容字符与所对应的统一字符外观，可以说无区别
1. 拼音码表里无这些兼容区字符

```
   兼容字符  -> 所对应的统一字符
郎 63788 F92C -> U+90CE , U+90DE
凉 63865 F979 -> U+51C9 
秊 63893 F995 -> U+79CA
裏 63975 F9E7 -> U+88CF
隣 63985 F9F1 -> U+96A3
兀 64012 FA0C -> U+5140
嗀 64013 FA0D -> U+55C0
```

另外的讨论见 https://github.com/fcitx/libime/issues/33