### PR TITLE
把“大”放在d的第二候选

### DIFF
--- a/wubi86_jidian.dict.yaml
+++ b/wubi86_jidian.dict.yaml
@@ -8322,6 +8322,7 @@ SD卡	sdhh
 驻京	cyyi
 圣诞夜	cyyw
 在	d
+大	d
 石	d
 左	da
 泰勒斯	daad


### PR DESCRIPTION
“大”是键名，放在第二候选符合习惯，也和其他键统一。