### PR TITLE
赵孟𫖯 的 𫖯

### DIFF
--- a/pinyin_simp.dict.yaml
+++ b/pinyin_simp.dict.yaml
@@ -2347,6 +2347,7 @@ sort: by_weight
 傅	fu	1163
 符	fu	1353
 附	fu	1595
+𫖯	fu	1648
 父	fu	1755
 府	fu	1757
 赴	fu	2178


### PR DESCRIPTION
pinyin_simp 缺少 “𫖯” 这个汉字 