### PR TITLE
fix: 教程单字模式无法正常使用

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,8 +368,8 @@ translator:
 如果你是单字派，只打单字，可以修改 `wubi86_jidian.schema.yaml` 这个文件，找到以下位置，根据需要去除对应行前面的 `#`，重新部署即可生效
 ```yaml
   filters:
-#   - lua_filter@single_char_first_filter # 单字优先
-#    - lua_filter@single_char_only # 纯单字
+#    - lua_filter@*wubi86_jidian_single_char_first_filter # 单字优先
+#    - lua_filter@*wubi86_jidian_single_char_only # 纯单字
 ```
 
 ### 9. 隐藏候选窗口（Windows）

--- a/lua/wubi86_jidian_single_char_first_filter.lua
+++ b/lua/wubi86_jidian_single_char_first_filter.lua
@@ -1,5 +1,5 @@
 --- 过滤器：单字在先
-function wubi86_jidian_single_char_first_filter(input)
+local function wubi86_jidian_single_char_first_filter(input)
     local l = {}
     for cand in input:iter() do
         if (utf8.len(cand.text) == 1) then

--- a/lua/wubi86_jidian_single_char_only.lua
+++ b/lua/wubi86_jidian_single_char_only.lua
@@ -1,5 +1,5 @@
 --- 过滤器：只显示单字
-function wubi86_jidian_single_char_only(input)
+local function wubi86_jidian_single_char_only(input)
     for cand in input:iter() do
         if (utf8.len(cand.text) == 1) then
             yield(cand)

--- a/wubi86_jidian.schema.yaml
+++ b/wubi86_jidian.schema.yaml
@@ -51,14 +51,11 @@ engine:
     - table_translator
     - lua_translator@*wubi86_jidian_date_translator # 日期、时间、星期
     - lua_translator@*wubi86_jidian_calculator # 计算器：二元运算，coco 开头，如 coco56*34 coco24/1024
-#    - lua_translator@*wubi86_jidian_single_char_first_filter # 单字优先
-#    - lua_translator@*wubi86_jidian_single_char_only # 单字过滤：只显示单字
-
     - history_translator@repeat_last_input # 重复上一次输入，对应下面的 repeat_last_input
   filters:
     - simplifier@tradition
-#    - lua_filter@single_char_first_filter # 单字优先
-#    - lua_filter@single_char_only # 纯单字
+#    - lua_filter@*wubi86_jidian_single_char_first_filter # 单字优先
+#    - lua_filter@*wubi86_jidian_single_char_only # 纯单字
 
 
 


### PR DESCRIPTION
您好，我是「仓输入法」的作者。

因我这里有反馈极点五笔-单字过滤无法使用，发现是配置文件中 lua 的函数名称不对，所以提交了 PR。

[#567](https://github.com/imfuxiao/Hamster/issues/567)