### PR TITLE
fix 裤衩

### DIFF
--- a/wubi86_jidian.dict.yaml
+++ b/wubi86_jidian.dict.yaml
@@ -49318,7 +49318,6 @@ MacbookPro	mbp	10
 实验	pucw	10
 褦	pucx	10
 衩	pucy	20
-裤杈	pucy	10
 实	pud	10
 袏	puda	10
 袸	pudb	10
@@ -49549,6 +49548,7 @@ MacbookPro	mbp	10
 衴	pupq	10
 衬衫	pupu	30
 被褥	pupu	20
+裤衩	pupu	20
 襁褓	pupu	10
 被窝	pupw	20
 袕	pupw	10


### PR DESCRIPTION
裤杈 错误，正确的是 裤衩，对应的五笔编码也改正了。