### PR TITLE
fix 别字

### DIFF
--- a/wubi86_jidian.dict.yaml
+++ b/wubi86_jidian.dict.yaml
@@ -26277,7 +26277,7 @@ HDR	hdr	10
 鴜	hxwo	10
 此人	hxww	10
 雌	hxwy	10
- 占比	hxx	20
+占比	hxx	20
 紫	hxx	10
 紫红	hxxa	10
 紫	hxxi	10
@@ -83560,7 +83560,7 @@ XBox	xbox	10
 弧	xrcy	10
 弧面	xrdm	10
 弧月	xree	10
-缝年过节	xrfa	10
+逢年过节	trfa	10
 缴款	xrff	10
 红白喜事	xrfg	10
 绵远	xrfq	10


### PR DESCRIPTION
“缝年过节” 错误，正确的是 ”逢年过节“。
“占比” 一行，格式优化。