### PR TITLE
feat: 增加东风破安装方式

### DIFF
--- a/plum/full.recipe.yaml
+++ b/plum/full.recipe.yaml
@@ -1,0 +1,17 @@
+# encoding: utf-8
+---
+recipe:
+  Rx: plum/full
+  args:
+  description: >-
+    全量安装、更新
+install_files: >-
+  imgs/*.*
+  lua/*.*
+  仓键盘布局/*.*
+  default.custom.yaml
+  squirrel.custom.yaml
+  weasel.custom.yaml
+  numbers.schema.yaml
+  pinyin_simp*.yaml
+  wubi86_jidian*.*


### PR DESCRIPTION
```
git clone https://github.com/rime/plum
cd plum

#代码合并前安装命令:
bash rime-install allran/rime-wubi86-jidian:plum/full
#合并后安装命令:
bash rime-install KyleBing/rime-wubi86-jidian:plum/full
#最後再點一下鼠须管的[重新部署]按钮就行
```

